### PR TITLE
Adding support for debug backtrace in PHP < 5.3.6

### DIFF
--- a/src/OcraServiceManager/ServiceManager/Logger.php
+++ b/src/OcraServiceManager/ServiceManager/Logger.php
@@ -127,7 +127,7 @@ class Logger implements ListenerAggregateInterface
             'requested_name'  => $requestedName,
             'canonical_name'  => $canonicalName,
             'method'          => $methodName,
-            'trace'           => $trace ?: debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT),
+            'trace'           => $trace ?: debug_backtrace(true),
         );
     }
 


### PR DESCRIPTION
`"php": "<5.3.6"` has no constants defined for `DEBUG_BACKTRACE_PROVIDE_OBJECT`
